### PR TITLE
bug #8: properly implement required_message.

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -20,16 +20,17 @@
       return value;
     }
   };
-  surveyFields = ['type', 'name', 'label', 'hint', 'required', 'read_only', 'default', 'constraint', 'constraint_message', 'relevant', 'calculation', 'choice_filter', 'parameters', 'appearance'];
+  surveyFields = ['type', 'name', 'label', 'hint', 'required', 'required_message', 'read_only', 'default', 'constraint', 'constraint_message', 'relevant', 'calculation', 'choice_filter', 'parameters', 'appearance'];
   choicesFields = ['list name', 'name', 'label'];
-  multilingualFields = ['label', 'hint', 'constraint_message'];
+  multilingualFields = ['label', 'hint', 'required_message', 'constraint_message'];
   pruneFalse = ['required', 'read_only', 'range', 'length', 'count'];
   fieldnameConversion = {
     defaultValue: 'default',
     relevance: 'relevant',
     calculate: 'calculation',
     invalidText: 'constraint_message',
-    readOnly: 'read_only'
+    readOnly: 'read_only',
+    requiredText: 'required_message'
   };
   typeConversion = {};
   choiceTypeConversion = {

--- a/spec/src/convert-question-spec.ls
+++ b/spec/src/convert-question-spec.ls
@@ -279,7 +279,16 @@ describe 'required' -> # in which we briefly become a bit existential.
     falsy = { type: \inputText, required: false } |> convert-simple
     expect(falsy.required).toBe(undefined)
 
-# required_message::lang is in the xlsform spec but is not in the build featureset.
+describe 'required message' ->
+  test 'multilingual passthrough' ->
+    result = { type: \inputNumber, requiredText: { en: \fun, sv: \roligt } } |> convert-simple
+    expect(result.requiredText).toBe(undefined)
+    expect(result.required_message).toEqual({ en: \fun, sv: \roligt })
+
+  test 'empty pruning' ->
+    result = { type: \inputNumber, requiredText: {} } |> convert-simple
+    expect(result.requiredText).toBe(undefined)
+    expect(result.required_message).toBe(undefined)
 
 describe 'default' ->
   test 'value is passed through' ->

--- a/src/convert.ls
+++ b/src/convert.ls
@@ -12,10 +12,10 @@ expr-value = (value) ->
   | otherwise                 => value
 
 # conversion constants.
-survey-fields = <[ type name label hint required read_only default constraint constraint_message relevant calculation choice_filter parameters appearance ]>
+survey-fields = <[ type name label hint required required_message read_only default constraint constraint_message relevant calculation choice_filter parameters appearance ]>
 choices-fields = [ 'list name', \name, \label ]
 
-multilingual-fields = <[ label hint constraint_message ]> # these fields have ::lang syntax/support.
+multilingual-fields = <[ label hint required_message constraint_message ]> # these fields have ::lang syntax/support.
 prune-false = <[ required read_only range length count ]> # these fields default to 'no', so just leave them out for a cleaner output.
 
 fieldname-conversion =
@@ -24,6 +24,7 @@ fieldname-conversion =
   calculate: \calculation
   invalidText: \constraint_message
   readOnly: \read_only
+  requiredText: \required_message
 
 type-conversion = {} # currently unused
 


### PR DESCRIPTION
* as you can see from the diff, there was a time when build2xlsform was
  correct not to implement this feature. but then requiredText got added
  to build itself, and not here.
* resolves #8.