### PR TITLE
Add metadata kind "Start Geopoint"

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -60,7 +60,8 @@
     'Username': 'username',
     'Subscriber ID': 'subscriberid',
     'SIM Serial': 'simserial',
-    'Phone Number': 'phonenumber'
+    'Phone Number': 'phonenumber',
+    'Start Geopoint': 'start-geopoint'
   };
   appearanceNoops = ['Default (GPS)', 'Default'];
   appearanceConversion = {

--- a/spec/src/convert-question-spec.ls
+++ b/spec/src/convert-question-spec.ls
@@ -149,6 +149,9 @@ describe \type ->
     simserial = { type: \metadata, kind: 'SIM Serial' } |> convert-simple
     expect(simserial.type).toBe(\simserial)
 
+    startgeopoint = { type: \metadata, kind: 'Start Geopoint' } |> convert-simple
+    expect(startgeopoint.type).toBe(\start-geopoint)
+
     phonenumber = { type: \metadata, kind: 'Phone Number' } |> convert-simple
     expect(phonenumber.type).toBe(\phonenumber)
 

--- a/src/convert.ls
+++ b/src/convert.ls
@@ -56,6 +56,7 @@ metadata-type-conversion =
   'Subscriber ID': \subscriberid
   'SIM Serial': \simserial
   'Phone Number': \phonenumber
+  'Start Geopoint': \start-geopoint
 
 appearance-noops = [ 'Default (GPS)', 'Default' ]
 


### PR DESCRIPTION
This is a patch to translate an XForm XML with a metadata field of kind `Start Geopoint` into an XLSForm with a field of type `start-geopoint`.
This patch is required to keep export to XLSForm working when merging https://github.com/getodk/build/pull/241.

Against https://github.com/getodk/build/pull/241 it works as expected, it adds a field of type `start-geopoint` for a metadata field of kind "Start Geopoint".
I've added a test for `start-geopoint`, `make test` now passes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getodk/build2xlsform/12)
<!-- Reviewable:end -->
