### PR TITLE
Export static form id and incrementing version #13

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -310,7 +310,7 @@
     result = withColumn(result, 'form_title', isNonsense((ref$ = form.metadata) != null ? ref$.htitle : void 8)
       ? form.title
       : (ref1$ = form.metadata) != null ? ref1$.htitle : void 8);
-    result = withColumn(result, 'form_id', "build_" + ((ref2$ = form.title) != null ? ref2$.replace(/([^a-z0-9]+)/ig, '-') : void 8) + "_" + Math.floor(new Date().getTime() / 1000));
+    result = withColumn(result, 'form_id', ((ref2$ = form.title) != null ? ref2$.replace(/([^a-z0-9]+)/ig, '-') : void 8) + "");
     for (i$ = 0, len$ = (ref3$ = ['public_key', 'submission_url', 'instance_name']).length; i$ < len$; ++i$) {
       attr = ref3$[i$];
       if (((ref4$ = form.metadata) != null ? ref4$[attr] : void 8) != null) {
@@ -319,6 +319,8 @@
     }
     if ((ref3$ = form.metadata) != null && ref3$.user_version) {
       result = withColumn(result, 'version', form.metadata.user_version);
+    } else {
+      result = withColumn(result, 'version', Math.floor(new Date().getTime() / 1000) + "");
     }
     return result;
   };

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -320,7 +320,7 @@
     if ((ref3$ = form.metadata) != null && ref3$.user_version) {
       result = withColumn(result, 'version', form.metadata.user_version);
     } else {
-      result = withColumn(result, 'version', Math.floor(new Date().getTime() / 1000) + "");
+      result = withColumn(result, 'version', Math.floor(new Date().getTime() / 1000));
     }
     return result;
   };

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -60,7 +60,8 @@
     'Username': 'username',
     'Subscriber ID': 'subscriberid',
     'SIM Serial': 'simserial',
-    'Phone Number': 'phonenumber'
+    'Phone Number': 'phonenumber',
+    'Start Geopoint': 'start-geopoint'
   };
   appearanceNoops = ['Default (GPS)', 'Default'];
   appearanceConversion = {

--- a/spec/src/convert-form-spec.ls
+++ b/spec/src/convert-form-spec.ls
@@ -398,9 +398,11 @@ describe 'settings generation' ->
   test 'generates expected fields and values' ->
     result = gen-settings({ title: \myform })
 
-    expect(result[0]).toEqual([ \form_title, \form_id ])
+    expect(result[0]).toEqual([ \form_title, \form_id, \version ])
     expect(result[1][0]).toBe(\myform)
-    expect(result[1][1]).toMatch(/build_myform_[0-9]+/)
+    expect(result[1][1]).toBe(\myform)
+    expect(result[1][2]).toMatch(/[0-9]+/)
+
 
   test 'uses metadata htitle for form title if provided' ->
     result = gen-settings({ title: \myform, metadata: { htitle: 'override title' } })
@@ -425,12 +427,12 @@ describe 'settings generation' ->
 
   test 'sanitizes form title for form_id' ->
     result = gen-settings({ title: 'Untitled! Test Form' })
-    expect(result[1][1]).toMatch(/build_Untitled-Test-Form_[0-9]+/)
+    expect(result[1][1]).toMatch(/Untitled-Test-Form/)
 
   test 'part of complete workbook generation' ->
     result = convert-form({ title: 'Test Form', metadata: { activeLanguages: { 0: \en, _counter: 0 } }, controls: [] })
     expect(result[2].name).toBe(\settings)
-    expect(result[2].data[0]).toEqual([ \form_title, \form_id ])
+    expect(result[2].data[0]).toEqual([ \form_title, \form_id, \version ])
     expect(result[2].data[1][0]).toBe('Test Form')
-    expect(result[2].data[1][1]).toMatch(/build_Test-Form_[0-9]+/)
+    expect(result[2].data[1][1]).toMatch(/Test-Form/)
 

--- a/spec/src/convert-question-spec.ls
+++ b/spec/src/convert-question-spec.ls
@@ -149,6 +149,9 @@ describe \type ->
     simserial = { type: \metadata, kind: 'SIM Serial' } |> convert-simple
     expect(simserial.type).toBe(\simserial)
 
+    startgeopoint = { type: \metadata, kind: 'Start Geopoint' } |> convert-simple
+    expect(startgeopoint.type).toBe(\start-geopoint)
+
     phonenumber = { type: \metadata, kind: 'Phone Number' } |> convert-simple
     expect(phonenumber.type).toBe(\phonenumber)
 

--- a/src/convert.ls
+++ b/src/convert.ls
@@ -261,7 +261,7 @@ gen-settings = (form) ->
   if form.metadata?.user_version
     result = with-column(result, \version, form.metadata.user_version)
   else
-    result = with-column(result, \version, "#{Math.floor((new Date()).getTime() / 1000)}")
+    result = with-column(result, \version, Math.floor((new Date()).getTime() / 1000))
 
   result
 

--- a/src/convert.ls
+++ b/src/convert.ls
@@ -253,13 +253,15 @@ gen-settings = (form) ->
   result = [ [], [] ]
 
   result = with-column(result, \form_title, if is-nonsense(form.metadata?.htitle) then form.title else form.metadata?.htitle)
-  result = with-column(result, \form_id, "build_#{form.title?.replace(/([^a-z0-9]+)/ig, '-')}_#{Math.floor((new Date()).getTime() / 1000)}")
+  result = with-column(result, \form_id, "#{form.title?.replace(/([^a-z0-9]+)/ig, '-')}")
 
   for attr in [ \public_key, \submission_url, \instance_name ] when form.metadata?[attr]?
     result = with-column(result, attr, form.metadata[attr])
 
   if form.metadata?.user_version
     result = with-column(result, \version, form.metadata.user_version)
+  else
+    result = with-column(result, \version, "#{Math.floor((new Date()).getTime() / 1000)}")
 
   result
 

--- a/src/convert.ls
+++ b/src/convert.ls
@@ -56,6 +56,7 @@ metadata-type-conversion =
   'Subscriber ID': \subscriberid
   'SIM Serial': \simserial
   'Phone Number': \phonenumber
+  'Start Geopoint': \start-geopoint
 
 appearance-noops = [ 'Default (GPS)', 'Default' ]
 


### PR DESCRIPTION
Closes #13 
Required for https://github.com/getodk/build/pull/239, see that PR for discussion of behaviour.
Tested locally, exports form id (sanitized name) and version (10 digit number) as expected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getodk/build2xlsform/14)
<!-- Reviewable:end -->
