### PR TITLE
Support guidance hint and short label

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -20,9 +20,9 @@
       return value;
     }
   };
-  surveyFields = ['type', 'name', 'label', 'hint', 'required', 'required_message', 'read_only', 'default', 'constraint', 'constraint_message', 'relevant', 'calculation', 'choice_filter', 'parameters', 'appearance'];
+  surveyFields = ['type', 'name', 'label', 'hint', 'guidance_hint', 'required', 'required_message', 'read_only', 'default', 'constraint', 'constraint_message', 'relevant', 'calculation', 'choice_filter', 'parameters', 'appearance'];
   choicesFields = ['list name', 'name', 'label'];
-  multilingualFields = ['label', 'hint', 'required_message', 'constraint_message'];
+  multilingualFields = ['label', 'hint', 'guidance_hint', 'required_message', 'constraint_message'];
   pruneFalse = ['required', 'read_only', 'range', 'length', 'count'];
   fieldnameConversion = {
     defaultValue: 'default',
@@ -30,7 +30,8 @@
     calculate: 'calculation',
     invalidText: 'constraint_message',
     readOnly: 'read_only',
-    requiredText: 'required_message'
+    requiredText: 'required_message',
+    guidance: 'guidance_hint'
   };
   typeConversion = {};
   choiceTypeConversion = {

--- a/src/convert.ls
+++ b/src/convert.ls
@@ -12,10 +12,10 @@ expr-value = (value) ->
   | otherwise                 => value
 
 # conversion constants.
-survey-fields = <[ type name label hint required required_message read_only default constraint constraint_message relevant calculation choice_filter parameters appearance ]>
+survey-fields = <[ type name label hint guidance_hint required required_message read_only default constraint constraint_message relevant calculation choice_filter parameters appearance ]>
 choices-fields = [ 'list name', \name, \label ]
 
-multilingual-fields = <[ label hint required_message constraint_message ]> # these fields have ::lang syntax/support.
+multilingual-fields = <[ label hint guidance_hint required_message constraint_message ]> # these fields have ::lang syntax/support.
 prune-false = <[ required read_only range length count ]> # these fields default to 'no', so just leave them out for a cleaner output.
 
 fieldname-conversion =
@@ -25,6 +25,7 @@ fieldname-conversion =
   invalidText: \constraint_message
   readOnly: \read_only
   requiredText: \required_message
+  guidance: \guidance_hint
 
 type-conversion = {} # currently unused
 


### PR DESCRIPTION
This is an early PR to share the newly added support for guidance hint while working on adding an error message for the not yet supported short label.

Testing with latest Build master confirms that this PR needs to handle short label, currently it doesn't generate a well formed XLSX.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getodk/build2xlsform/18)
<!-- Reviewable:end -->
