### PR TITLE
new: Dockerfile and GHA

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,53 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+# Publish `v1.2.3` tags as releases.
+on:
+  push:
+    tags:
+      - v*
+    # DEBUG: once working in upstream, drop the branches.
+    branches:
+      - main
+      - master
+      - '21-docker'
+
+name: docker
+
+env:
+  IMAGE_NAME: odkbuild2xlsform
+
+jobs:
+  # Push image to GitHub Packages.
+  # See also https://docs.docker.com/docker-hub/builds/
+  push:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build image
+        run: docker build . --file Dockerfile --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"
+
+      - name: Log in to registry
+        # This is where you will update the PAT to GITHUB_TOKEN
+        run: echo "${{ secrets.GH_PAT }}" | docker login ghcr.io -u ${{ secrets.GH_ACTOR }} --password-stdin
+
+      - name: Push image
+        run: |
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
+
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "main" ] && VERSION=latest
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,11 +5,6 @@ on:
   push:
     tags:
       - v*
-    # DEBUG: once working in upstream, drop the branches.
-    branches:
-      - main
-      - master
-      - '21-docker'
 
 name: docker
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:10.19.0
-LABEL author="GetODK Inc."
+LABEL author="ODK"
 LABEL maintainer="ODK Build maintainers"
-LABEL description="ODK build2xlsform, a Xforms to XLSForm converter"
+LABEL description="ODK build2xlsform, a ODK XForms to XLSForm converter"
 
 WORKDIR /srv/odkbuild2xlsform
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:10.19.0
 LABEL author="ODK"
 LABEL maintainer="ODK Build maintainers"
-LABEL description="ODK build2xlsform, a ODK XForms to XLSForm converter"
+LABEL description="ODK build2xlsform, an ODK XForms to XLSForm converter"
 
 WORKDIR /srv/odkbuild2xlsform
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:10.19.0
 LABEL author="ODK"
 LABEL maintainer="ODK Build maintainers"
-LABEL description="ODK build2xlsform, an ODK XForms to XLSForm converter"
+LABEL description="Generate an XLSForm from an ODK Build Xform"
 
 WORKDIR /srv/odkbuild2xlsform
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:10.19.0
+LABEL author="GetODK Inc."
+LABEL maintainer="ODK Build maintainers"
+LABEL description="ODK build2xlsform, a Xforms to XLSForm converter"
+
+WORKDIR /srv/odkbuild2xlsform
+COPY . .
+RUN make
+EXPOSE 8686
+CMD ["node", "lib/server.js"]


### PR DESCRIPTION
This PR brings a Dockerfile and a GH action to build and push the image to ghcr.io. The action requires two secrets:

```
echo "${{ secrets.GH_PAT }}" | docker login ghcr.io -u ${{ secrets.GH_ACTOR }} --password-stdin
```

GH_PAT and GH_ACTOR. It works nicely with my own GH username as actor (florianm) and my PAT. The image https://github.com/orgs/florianm/packages/container/package/odkbuild2xlsform is used and works with https://github.com/getodk/build/pull/283.

There is one change to make before merging, deletion of the "branches" key (so I can trigger builds during dev) to only build and push the Docker image when a new Git tag is pushed.
I have made this change after an initial image was built to use in https://github.com/getodk/build/pull/283, and now dropped the "branches" key.

I expect that this PR will work once the getodk/build2xlsform repo has the two secrets defined. The only way to find out for sure is to merge. I see low risk in a merge, as it doesn't impact the source install at all.


Fixes #21 
