### PR TITLE
fix: numeric constraints and range values are numeric

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -17,7 +17,7 @@
       value):
       return "'" + value + "'";
     default:
-      return +value;
+      return value;
     }
   };
   surveyFields = ['type', 'name', 'label', 'hint', 'guidance_hint', 'required', 'required_message', 'read_only', 'default', 'constraint', 'constraint_message', 'relevant', 'calculation', 'choice_filter', 'parameters', 'appearance'];

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -17,7 +17,7 @@
       value):
       return "'" + value + "'";
     default:
-      return value;
+      return +value;
     }
   };
   surveyFields = ['type', 'name', 'label', 'hint', 'guidance_hint', 'required', 'required_message', 'read_only', 'default', 'constraint', 'constraint_message', 'relevant', 'calculation', 'choice_filter', 'parameters', 'appearance'];
@@ -260,9 +260,9 @@
     if (question.type === 'range') {
       selectRange = (ref$ = question.selectRange, delete question.selectRange, ref$);
       question.parameters = {
-        start: selectRange != null ? selectRange.min : void 8,
-        end: selectRange != null ? selectRange.max : void 8,
-        step: (ref$ = question.selectStep, delete question.selectStep, ref$)
+        start: +(selectRange != null ? selectRange.min : void 8),
+        end: +(selectRange != null ? selectRange.max : void 8),
+        step: +(ref$ = question.selectStep, delete question.selectStep, ref$)
       };
       question.appearance = rangeAppearanceConversion[ref$ = question.appearance, delete question.appearance, ref$];
       if (question.sliderTicks === false) {

--- a/spec/src/convert-question-spec.ls
+++ b/spec/src/convert-question-spec.ls
@@ -228,7 +228,7 @@ describe \constraint ->
 
   test 'build number range constraint generation (max)' ->
     result = { type: \inputNumber, range: { max: 3, maxInclusive: true } } |> convert-simple
-    expect(result.constraint).toBe('(. <= 3)')
+    expect(result.constraint).toBe('(. <= 3)')  
 
   test 'build text range false pruning' ->
     result = { type: \inputText, range: false } |> convert-simple
@@ -545,4 +545,7 @@ describe 'parameters' ->
     for appearance in [ 'Slider', 'Vertical Slider', 'Picker' ]
       result = { type: \inputNumeric, appearance, selectRange: { min: 13, max: 42 }, selectStep: 1.5 } |> convert-simple
       expect(result.parameters).toBe('start=13 end=42 step=1.5')
-
+    # Slider parameters are quoted in XForm but must be numeric in XLSForm
+    for appearance in [ 'Slider', 'Vertical Slider', 'Picker' ]
+      result = { type: \inputNumeric, appearance, selectRange: { min: \13, max: \42 }, selectStep: \1.5 } |> convert-simple
+      expect(result.parameters).toBe('start=13 end=42 step=1.5')

--- a/spec/src/convert-question-spec.ls
+++ b/spec/src/convert-question-spec.ls
@@ -228,7 +228,7 @@ describe \constraint ->
 
   test 'build number range constraint generation (max)' ->
     result = { type: \inputNumber, range: { max: 3, maxInclusive: true } } |> convert-simple
-    expect(result.constraint).toBe('(. <= 3)')  
+    expect(result.constraint).toBe('(. <= 3)')
 
   test 'build text range false pruning' ->
     result = { type: \inputText, range: false } |> convert-simple

--- a/src/convert.ls
+++ b/src/convert.ls
@@ -9,7 +9,7 @@ is-nonsense = (value) -> !value? or (value is '') or (is-type(\Object, value) an
 expr-value = (value) ->
   | value is null             => "''"
   | value |> is-type(\String) => "'#value'"
-  | otherwise                 => +value
+  | otherwise                 => value
 
 # conversion constants.
 survey-fields = <[ type name label hint guidance_hint required required_message read_only default constraint constraint_message relevant calculation choice_filter parameters appearance ]>

--- a/src/convert.ls
+++ b/src/convert.ls
@@ -9,7 +9,7 @@ is-nonsense = (value) -> !value? or (value is '') or (is-type(\Object, value) an
 expr-value = (value) ->
   | value is null             => "''"
   | value |> is-type(\String) => "'#value'"
-  | otherwise                 => value
+  | otherwise                 => +value
 
 # conversion constants.
 survey-fields = <[ type name label hint guidance_hint required required_message read_only default constraint constraint_message relevant calculation choice_filter parameters appearance ]>
@@ -220,7 +220,7 @@ convert-question = (question, context, prefix = []) ->
   # range parameters.
   if question.type is \range
     select-range = (delete question.selectRange)
-    question.parameters = { start: select-range?.min, end: select-range?.max, step: (delete question.selectStep) }
+    question.parameters = { start: +select-range?.min, end: +select-range?.max, step: +(delete question.selectStep) }
     question.appearance = range-appearance-conversion[delete question.appearance]
     if question.sliderTicks is false
       question.appearance = ((question.appearance ? '') + ' no-ticks').trim()


### PR DESCRIPTION
* livescript is terse, but at least the numeric cast operator is a big plus
* convert-question for type "range" casts min, max, step to numeric
* no extensive testing done yet with different ranges
* tested: numeric question with appearance slider > XLSForm > Central > Collect works
* tested: numeric question with valid range > XLSForm > Central > Collect works
* Fix #20 

update:
* constraints work even if the values are strings - won't cast them
* add tests to verify that range parameters given as string are getting converted to int