### PR TITLE
new: support auto_send and auto_delete

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -312,7 +312,7 @@
       ? form.title
       : (ref1$ = form.metadata) != null ? ref1$.htitle : void 8);
     result = withColumn(result, 'form_id', ((ref2$ = form.title) != null ? ref2$.replace(/([^a-z0-9]+)/ig, '-') : void 8) + "");
-    for (i$ = 0, len$ = (ref3$ = ['public_key', 'submission_url', 'instance_name']).length; i$ < len$; ++i$) {
+    for (i$ = 0, len$ = (ref3$ = ['public_key', 'submission_url', 'instance_name', 'auto_send', 'auto_delete']).length; i$ < len$; ++i$) {
       attr = ref3$[i$];
       if (((ref4$ = form.metadata) != null ? ref4$[attr] : void 8) != null) {
         result = withColumn(result, attr, form.metadata[attr]);

--- a/spec/src/convert-form-spec.ls
+++ b/spec/src/convert-form-spec.ls
@@ -420,6 +420,39 @@ describe 'settings generation' ->
     expect(result[0][2]).toBe(\instance_name)
     expect(result[1][2]).toBe(\testname)
 
+  test 'passes through auto_send and auto_delete form properties' ->
+    # do it in two passes to ensure partial generation works:
+    result = gen-settings({ title: \myform, metadata: { auto_send: 'true', auto_delete: 'false' } })
+    expect(result[0][2]).toBe(\auto_send)
+    expect(result[1][2]).toBe(\true)
+    expect(result[0][3]).toBe(\auto_delete)
+    expect(result[1][3]).toBe(\false)
+
+    result = gen-settings({ title: \myform, metadata: { auto_send: 'false', auto_delete: 'true' } })
+    expect(result[0][2]).toBe(\auto_send)
+    expect(result[1][2]).toBe(\false)
+    expect(result[0][3]).toBe(\auto_delete)
+    expect(result[1][3]).toBe(\true)
+
+    result = gen-settings({ title: \myform, metadata: { public_key: 'testkey', submission_url: 'testurl', auto_send: 'true', auto_delete: 'false' } })
+    expect(result[0][2]).toBe(\public_key)
+    expect(result[1][2]).toBe(\testkey)
+    expect(result[0][3]).toBe(\submission_url)
+    expect(result[1][3]).toBe(\testurl)
+    expect(result[0][4]).toBe(\auto_send)
+    expect(result[1][4]).toBe(\true)
+    expect(result[0][5]).toBe(\auto_delete)
+    expect(result[1][5]).toBe(\false)
+
+
+    result = gen-settings({ title: \myform, metadata: { public_key: 'testkey', submission_url: 'testurl', auto_delete: 'true' } })
+    expect(result[0][2]).toBe(\public_key)
+    expect(result[1][2]).toBe(\testkey)
+    expect(result[0][3]).toBe(\submission_url)
+    expect(result[1][3]).toBe(\testurl)
+    expect(result[0][4]).toBe(\auto_delete)
+    expect(result[1][4]).toBe(\true)    
+
   test 'passes through user-specified version', ->
     result = gen-settings({ title: \myform, metadata: { user_version: 'testversion' } })
     expect(result[0][2]).toBe(\version)

--- a/src/convert.ls
+++ b/src/convert.ls
@@ -256,7 +256,7 @@ gen-settings = (form) ->
   result = with-column(result, \form_title, if is-nonsense(form.metadata?.htitle) then form.title else form.metadata?.htitle)
   result = with-column(result, \form_id, "#{form.title?.replace(/([^a-z0-9]+)/ig, '-')}")
 
-  for attr in [ \public_key, \submission_url, \instance_name ] when form.metadata?[attr]?
+  for attr in [ \public_key, \submission_url, \instance_name, \auto_send, \auto_delete ] when form.metadata?[attr]?
     result = with-column(result, attr, form.metadata[attr])
 
   if form.metadata?.user_version


### PR DESCRIPTION
Assuming [this merged PR](https://github.com/XLSForm/pyxform/pull/178) means we can simply add any of the columns `auto_send` and `auto_delete`, respectively, with `true`/`false` values (or column omitted = default = follow ODK Collect settings).

* Close #22 
* Handles auto_send and auto_delete like e.g. instance_name
* Tested with a form: XML has `orx:auto-send`, here we receive `\auto_send` - ouput: 
[22-autosend.xlsx](https://github.com/getodk/build2xlsform/files/8103316/22-autosend.xlsx)
* Added tests