### PR TITLE
new: support appearance bearing

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -70,7 +70,8 @@
     'Manual (No GPS)': 'placement-map',
     'Minimal (spinner)': 'minimal',
     'Table': 'label',
-    'Horizontal Layout': 'horizontal'
+    'Horizontal Layout': 'horizontal',
+    'Bearing': 'bearing'
   };
   rangeAppearanceConversion = {
     'Vertical Slider': 'vertical',
@@ -241,7 +242,9 @@
       question.appearance = 'field-list';
     }
     question.type = question.type === 'inputNumeric'
-      ? question.appearance == null || question.appearance === 'Textbox' ? (delete question.appearance, ((ref$ = (ref1$ = question.kind, delete question.kind, ref1$)) != null ? ref$ : 'integer').toLowerCase()) : 'range'
+      ? question.appearance == null || question.appearance === 'Textbox'
+        ? (delete question.appearance, ((ref$ = (ref1$ = question.kind, delete question.kind, ref1$)) != null ? ref$ : 'integer').toLowerCase())
+        : question.appearance === 'bearing' ? 'decimal' : 'range'
       : question.type === 'inputMedia'
         ? mediaTypeConversion[(ref$ = (ref1$ = question.kind, delete question.kind, ref1$)) != null ? ref$ : 'Image']
         : question.type === 'inputDate'

--- a/spec/src/convert-question-spec.ls
+++ b/spec/src/convert-question-spec.ls
@@ -362,6 +362,10 @@ describe 'appearance' ->
     result = { type: \inputNumeric, appearance: 'Textbox' } |> convert-simple
     expect(result.appearance).toBe(undefined)
 
+    result = { type: \inputNumeric, appearance: 'Bearing' } |> convert-simple
+    expect(result.type).toBe(\decimal)
+    expect(result.appearance).toBe(\bearing)
+
     result = { type: \inputNumeric, appearance: 'Slider' } |> convert-simple
     expect(result.appearance).toBe(undefined)
 

--- a/src/convert.ls
+++ b/src/convert.ls
@@ -67,6 +67,7 @@ appearance-conversion =
   'Minimal (spinner)': \minimal
   'Table': \label
   'Horizontal Layout': \horizontal
+  'Bearing': \bearing
 
 range-appearance-conversion =
   'Vertical Slider': \vertical
@@ -82,6 +83,7 @@ media-type-conversion =
   'Audio': \audio
   'Video': \video
   'Selfie Video': \video
+
 media-appearance-conversion =
   'New Image': \new
   'Signature': \signature
@@ -193,11 +195,14 @@ convert-question = (question, context, prefix = []) ->
     question.appearance = \field-list
 
   # massage the type.
+  # numeric inputs of type decimal are either Textbox (default), bearing, or range widgets (slider, vertical slider, or picker).
   question.type =
     if question.type is \inputNumeric
       if !question.appearance? or question.appearance is \Textbox
         delete question.appearance
-        ((delete question.kind) ? \integer).toLowerCase()
+        ((delete question.kind) ? \integer).toLowerCase()        
+      else if question.appearance is \bearing
+        \decimal
       else
         \range
     else if question.type is \inputMedia


### PR DESCRIPTION
* Inject logic for appearance `bearing` into convert-question > type between default (Textbox) and anything else (different range widgets)
* Add tests
* Tested with a simple form (type decimal, appearance bearing): [26-bearing.xlsx](https://github.com/getodk/build2xlsform/files/8103472/26-bearing.xlsx)
* Close #26

 